### PR TITLE
Update probot peer dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
     "prettier-check": "^2.0.0"
   },
   "peerDependencies": {
-    "probot": "^0.11.0"
+    "probot": ">= 0.11.0"
   },
   "engines": {
     "node": ">=7.7.0",


### PR DESCRIPTION
When installing node modules where probot and probot-config are dependencies, it keeps throwing a warning that a peer of probot ^0.11.0 is required but none is installed.  Probot is now on 6.x going on 7.x, so the peer dependency here should be updated to allow anything greater than 0.11.0.  I could also argue that it should be greater than or equal to 6.x, but would like to hear other opinions.