### PR TITLE
fix: use posix join for config path

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -85,7 +85,7 @@ function getBaseParams(params, base) {
  * @async
  */
 async function getConfig(context, fileName, defaultConfig) {
-  const filePath = path.join(CONFIG_PATH, fileName);
+  const filePath = path.posix.join(CONFIG_PATH, fileName);
   const params = context.repo({ path: filePath });
 
   const config = await loadYaml(context, params);


### PR DESCRIPTION
On Windows, doing path.join('.github', 'config.yml') returns .github\\config.yml. This is an incorrect file url as the correct url would be .github/config.yml. This PR fixes this by using `path.posix.join` instead of `path.join`