### PR TITLE
Add async/await to example

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,9 +48,9 @@ completely.
 const getConfig = require('probot-config');
 
 module.exports = robot => {
-  robot.on('push', context => {
+  robot.on('push', async context => {
     // Will look for 'test.yml' inside the '.github' folder
-    const config = getConfig(context, 'test.yml');
+    const config = await getConfig(context, 'test.yml');
   });
 };
 ```


### PR DESCRIPTION
Adds `async/await` to the example usage in the project's README. Since the exported function is in fact an `async` function and returns a promise, not waiting to resolve `getConfig()` would cause errors.