### PR TITLE
 Support default base repositories

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,6 +63,50 @@ other: GGG
 other: HHH
 ```
 
+Additionally, if there is no config file, but there is a repo in the org named
+`.github`, it will be used as a base repository.
+
+```yaml
+# octocat/repo1:.github/test.yaml <-- missing!
+# octocat/.github:test.yaml
+other: III
+```
+
+## Recipes
+
+### An opt-in pattern
+
+You may want to create a configuration that other projects in your org inherit
+from on an explicit opt-in basis.  Example:
+
+```yaml
+# octocat/.github:_test.yaml
+shared1: Will be inherited by repo1 and not repo2
+
+# octocat/repo1:.github/test.yaml
+# Inherits from octocat/.github:_test.yaml
+_extends: .github:_test.yaml
+
+# octocat/repo3:.github/test.yaml <--missing!
+# Is not merged with another config.
+```
+
+### An opt-out pattern
+
+Alternatively, you may want to default to the config in your `.github` project
+and occasionally opt-out.  Example:
+
+```yaml
+# octocat/.github:test.yaml
+shared1: Will be inherited by repo1 and not repo2
+
+# octocat/repo1:.github/test.yaml <-- missing!
+# Uses octocat/.github/test.yaml instead
+
+# octocat/repo3:.github/test.yaml <-- either empty or populated
+# Will not inherit shared1, since no _extends field is specified
+```
+
 ## Usage
 
 ```js

--- a/lib/index.js
+++ b/lib/index.js
@@ -11,6 +11,7 @@ const BASE_REGEX = new RegExp(
     '$',
   'i'
 );
+const DEFAULT_BASE = '.github';
 
 /**
  * Decodes and parses a YAML config file
@@ -101,14 +102,23 @@ async function getConfig(context, fileName, defaultConfig) {
   const params = context.repo({ path: filePath });
 
   const config = await loadYaml(context, params);
-  if (config == null || config[BASE_KEY] == null) {
-    return config && Object.assign({}, defaultConfig, config);
+  let baseRepo;
+  if (config == null) {
+    baseRepo = DEFAULT_BASE;
+  } else if (config != null && BASE_KEY in config) {
+    baseRepo = config[BASE_KEY];
+    delete config[BASE_KEY];
+  } else {
+    return Object.assign({}, defaultConfig, config);
   }
 
-  const baseParams = getBaseParams(params, config[BASE_KEY]);
+  const baseParams = getBaseParams(params, baseRepo);
   const baseConfig = await loadYaml(context, baseParams);
 
-  delete config[BASE_KEY];
+  if (config == null && baseConfig == null) {
+    return null;
+  }
+
   return Object.assign({}, defaultConfig, baseConfig, config);
 }
 

--- a/lib/index.test.js
+++ b/lib/index.test.js
@@ -30,16 +30,22 @@ function mockError(code) {
 test('returns null on 404', async () => {
   const spy = fn()
     .mockImplementationOnce(() => mockError(404))
+    .mockImplementationOnce(() => mockError(404))
     .mockImplementationOnce(() => mockError(500));
 
   const config = await getConfig(mockContext(spy), 'test.yml');
   expect(config).toEqual(null);
 
-  expect(spy).toHaveBeenCalledTimes(1);
-  expect(spy).toHaveBeenLastCalledWith({
+  expect(spy).toHaveBeenCalledTimes(2);
+  expect(spy).toHaveBeenCalledWith({
     owner: 'owner',
     repo: 'repo',
     path: '.github/test.yml',
+  });
+  expect(spy).toHaveBeenLastCalledWith({
+    owner: 'owner',
+    repo: '.github',
+    path: 'test.yml',
   });
 });
 
@@ -239,6 +245,27 @@ test('uses the root directory on a .github repo', async () => {
 
   const config = await getConfig(mockContext(spy), 'test.yml');
   expect(config).toEqual({ foo: 'foo', bar: 'bar', baz: 'baz' });
+
+  expect(spy).toHaveBeenCalledTimes(2);
+  expect(spy).toHaveBeenCalledWith({
+    owner: 'owner',
+    repo: 'repo',
+    path: '.github/test.yml',
+  });
+  expect(spy).toHaveBeenLastCalledWith({
+    owner: 'owner',
+    repo: '.github',
+    path: 'test.yml',
+  });
+});
+
+test('defaults to .github repo if no config found', async () => {
+  const spy = fn()
+    .mockImplementationOnce(() => mockError(404))
+    .mockImplementationOnce(() => 'foo: foo\nbar: bar');
+
+  const config = await getConfig(mockContext(spy), 'test.yml');
+  expect(config).toEqual({ foo: 'foo', bar: 'bar' });
 
   expect(spy).toHaveBeenCalledTimes(2);
   expect(spy).toHaveBeenCalledWith({


### PR DESCRIPTION
This change considers `.github` within the same org to be a default
base repository if none is specified.  This works even when no config
file is specificed in the inheriting repository.

Issue: #1 
Dependency: #6 