### PR TITLE
Allow specifying custom file paths

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,9 @@ other: BBB
 other: CCC # standalone, does not extend other configs
 ```
 
+Configs are shallow-merged, nested objects have to be redefined
+completely.
+
 You can also reference configurations from other organizations:
 
 ```yaml
@@ -38,21 +41,26 @@ _extends: other/probot-settings
 other: DDD
 ```
 
-Note that the files must be at the **exact same location** within the
-repositories. Configs are shallow-merged, nested objects have to be redefined
-completely.
+Additionally, you can specify a specific path for the configuration by
+appending a colon after the project.
 
-However, if a base repository is named `.github`, the config may optionally be
-stored relative to the root of the repository rather than relative a `.github/`
-directory.
+```yaml
+_extends: probot-settings:.github/other_test.yaml
+other: FFF
+```
+
+Note that by default, inherited configurations are in the **exact same
+location** within the repositories.  However, if a base repository is named
+`.github`, the default config path is relative to the root of the repository
+rather than relative to a `.github/` directory.
 
 ```yaml
 # octocat/repo1:.github/test.yaml
 _extends: .github
-other: FFF
+other: GGG
 
 # octocat/.github:test.yaml
-other: GGG
+other: HHH
 ```
 
 ## Usage

--- a/lib/index.js
+++ b/lib/index.js
@@ -3,7 +3,14 @@ const yaml = require('js-yaml');
 
 const CONFIG_PATH = '.github';
 const BASE_KEY = '_extends';
-const BASE_REGEX = /^(?:([a-z\d](?:[a-z\d]|-(?=[a-z\d])){0,38})\/)?([-_.\w\d]+)$/i;
+const BASE_REGEX = new RegExp(
+  '^' +
+  '(?:([a-z\\d](?:[a-z\\d]|-(?=[a-z\\d])){0,38})/)?' + // org
+  '([-_.\\w\\d]+)' + // project
+  '(?::([-_./\\w\\d]+\\.ya?ml))?' + // filename
+    '$',
+  'i'
+);
 
 /**
  * Decodes and parses a YAML config file
@@ -56,10 +63,15 @@ function getBaseParams(params, base) {
     throw new Error(`Invalid repository name in key "${BASE_KEY}": ${base}`);
   }
 
+  // In the case of a repo named `.github`, the root should be used as the
+  // relative path of the default config.
+  const defaultPath =
+    match[2] === '.github' ? path.basename(params.path) : params.path;
+
   return {
-    path: params.path,
     owner: match[1] || params.owner,
     repo: match[2],
+    path: match[3] || defaultPath,
   };
 }
 
@@ -94,11 +106,6 @@ async function getConfig(context, fileName, defaultConfig) {
   }
 
   const baseParams = getBaseParams(params, config[BASE_KEY]);
-  if (baseParams.repo === '.github') {
-    // In the case of a repo named `.github`, the root should be used as the
-    // relative path of the config.
-    baseParams.path = fileName;
-  }
   const baseConfig = await loadYaml(context, baseParams);
 
   delete config[BASE_KEY];

--- a/lib/index.test.js
+++ b/lib/index.test.js
@@ -138,6 +138,27 @@ test('merges a base config from another organization', async () => {
   });
 });
 
+test('merges a base config with a custom path', async () => {
+  const spy = fn()
+    .mockImplementationOnce(() => 'foo: foo\nbar: bar\n_extends: base:test.yml')
+    .mockImplementationOnce(() => 'bar: bar2\nbaz: baz');
+
+  const config = await getConfig(mockContext(spy), 'test.yml');
+  expect(config).toEqual({ foo: 'foo', bar: 'bar', baz: 'baz' });
+
+  expect(spy).toHaveBeenCalledTimes(2);
+  expect(spy).toHaveBeenCalledWith({
+    owner: 'owner',
+    repo: 'repo',
+    path: '.github/test.yml',
+  });
+  expect(spy).toHaveBeenLastCalledWith({
+    owner: 'owner',
+    repo: 'base',
+    path: 'test.yml',
+  });
+});
+
 test('ignores a missing base config', async () => {
   const spy = fn()
     .mockImplementationOnce(() => 'foo: foo\nbar: bar\n_extends: base')


### PR DESCRIPTION
This change allows syntax like:
```
_extends: base:otherdir/test.yml
```

This is necessary for maintaining an opt-in pattern when we begin
supporting default base repositories.