### PR TITLE
Always use the .github folder

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,10 +49,8 @@ _extends: probot-settings:.github/other_test.yaml
 other: FFF
 ```
 
-Note that by default, inherited configurations are in the **exact same
-location** within the repositories.  However, if a base repository is named
-`.github`, the default config path is relative to the root of the repository
-rather than relative to a `.github/` directory.
+Inherited configurations are in the **exact same location** within the 
+repositories.
 
 ```yaml
 # octocat/repo1:.github/test.yaml
@@ -68,11 +66,15 @@ Additionally, if there is no config file, but there is a repo in the org named
 
 ```yaml
 # octocat/repo1:.github/test.yaml <-- missing!
-# octocat/.github:test.yaml
+# octocat/.github:.github/test.yaml
 other: III
 ```
 
 ## Recipes
+
+These recipes are specific to usage of the .github repo name, which is the 
+recommended place to store your configuration files. Within the .github repository, 
+your configuration must live in a `.github/` folder.
 
 ### An opt-in pattern
 
@@ -80,7 +82,7 @@ You may want to create a configuration that other projects in your org inherit
 from on an explicit opt-in basis.  Example:
 
 ```yaml
-# octocat/.github:_test.yaml
+# octocat/.github:.github/_test.yaml
 shared1: Will be inherited by repo1 and not repo2
 
 # octocat/repo1:.github/test.yaml
@@ -97,7 +99,7 @@ Alternatively, you may want to default to the config in your `.github` project
 and occasionally opt-out.  Example:
 
 ```yaml
-# octocat/.github:test.yaml
+# octocat/.github:.github/test.yaml
 shared1: Will be inherited by repo1 and not repo2
 
 # octocat/repo1:.github/test.yaml <-- missing!

--- a/lib/index.js
+++ b/lib/index.js
@@ -64,15 +64,10 @@ function getBaseParams(params, base) {
     throw new Error(`Invalid repository name in key "${BASE_KEY}": ${base}`);
   }
 
-  // In the case of a repo named `.github`, the root should be used as the
-  // relative path of the default config.
-  const defaultPath =
-    match[2] === '.github' ? path.basename(params.path) : params.path;
-
   return {
     owner: match[1] || params.owner,
     repo: match[2],
-    path: match[3] || defaultPath,
+    path: match[3] || params.path,
   };
 }
 

--- a/lib/index.test.js
+++ b/lib/index.test.js
@@ -45,7 +45,7 @@ test('returns null on 404', async () => {
   expect(spy).toHaveBeenLastCalledWith({
     owner: 'owner',
     repo: '.github',
-    path: 'test.yml',
+    path: '.github/test.yml',
   });
 });
 
@@ -238,7 +238,7 @@ test('throws on an invalid base', async () => {
   }
 });
 
-test('uses the root directory on a .github repo', async () => {
+test('uses the .github directory on a .github repo', async () => {
   const spy = fn()
     .mockImplementationOnce(() => 'foo: foo\nbar: bar\n_extends: .github')
     .mockImplementationOnce(() => 'bar: bar2\nbaz: baz');
@@ -255,7 +255,7 @@ test('uses the root directory on a .github repo', async () => {
   expect(spy).toHaveBeenLastCalledWith({
     owner: 'owner',
     repo: '.github',
-    path: 'test.yml',
+    path: '.github/test.yml',
   });
 });
 
@@ -276,6 +276,6 @@ test('defaults to .github repo if no config found', async () => {
   expect(spy).toHaveBeenLastCalledWith({
     owner: 'owner',
     repo: '.github',
-    path: 'test.yml',
+    path: '.github/test.yml',
   });
 });


### PR DESCRIPTION
Closes https://github.com/probot/probot-config/issues/13

After some _long_ discussion with @probot/maintainers, we decided the best course of action would be to simply enforce `.github` folders in all repos, even the .github repo. This makes sense given GitHub Apps' permissioning system's 'single file' access option:

<img width="681" alt="screen shot 2018-07-19 at 2 05 44 pm" src="https://user-images.githubusercontent.com/13410355/42969980-dd11dfb4-8b5c-11e8-9b01-24853c1341f9.png">

cc/ @cco3 @jan-auer @nesl247 @dessant