### PR TITLE
Make compatible with probot 7.4.0

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -45,7 +45,7 @@ function deepMergeConfigs(configs, options) {
  */
 async function loadYaml(context, params) {
   try {
-    const response = await context.github.repos.getContent(params);
+    const response = await context.github.repos.getContents(params);
     return parseConfig(response.data.content);
   } catch (e) {
     if (e.code === 404) {

--- a/lib/index.test.js
+++ b/lib/index.test.js
@@ -3,7 +3,7 @@ const getConfig = require('./index');
 
 const { fn } = jest;
 
-function mockContext(getContent) {
+function mockContext(getContents) {
   return {
     repo(params) {
       return Object.assign(
@@ -17,8 +17,8 @@ function mockContext(getContent) {
 
     github: {
       repos: {
-        async getContent(params) {
-          const content = Buffer.from(getContent(params)).toString('base64');
+        async getContents(params) {
+          const content = Buffer.from(getContents(params)).toString('base64');
           return {
             data: {
               content,

--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
     "prettier-check": "^2.0.0"
   },
   "peerDependencies": {
-    "probot": ">= 0.11.0"
+    "probot": ">= 7.4.0"
   },
   "engines": {
     "node": ">=7.7.0",


### PR DESCRIPTION
Currently probot-config is broken when using in combination with probot 7.4.0.

This is because `getContent` was renamed to `getContents`. Anyone upgrading probot will face this issue and hopefully those projects have tested for this situation.

This PR will rename usages of getContent to getContents. In addition it changes the required probot version to 7.4.0, since this change will not be compatible with older probot versions.